### PR TITLE
Remove m4a support

### DIFF
--- a/netlify/functions/list.ts
+++ b/netlify/functions/list.ts
@@ -4,11 +4,7 @@ import { getDrive } from './_drive';
 function guessAudioMimeByName(name: string, driveMime?: string): string {
   const n = name.toLowerCase();
   if (n.endsWith('.mp3')) return 'audio/mpeg';
-  if (n.endsWith('.m4a') || n.endsWith('.aac')) return 'audio/mp4';
   if (driveMime && driveMime.startsWith('audio/')) return driveMime;
-  if ((n.endsWith('.m4a') || n.endsWith('.aac')) && driveMime === 'video/mp4') {
-    return 'audio/mp4';
-  }
   return driveMime ?? 'application/octet-stream';
 }
 
@@ -25,18 +21,10 @@ export const handler: Handler = async () => {
 
     const drive = getDrive();
 
-    // m4a が video/mp4 になっていることがあるため、検索は広めに
     const q = [
       `'${folderId}' in parents`,
       'trashed=false',
-      '(' +
-        [
-          "mimeType='audio/mpeg'",
-          "mimeType='audio/mp4'",
-          "mimeType='audio/x-m4a'",
-          "mimeType='video/mp4'", // m4a がこれで返る場合がある
-        ].join(' or ') +
-        ')',
+      "mimeType='audio/mpeg'",
     ].join(' and ');
 
     const res = await drive.files.list({

--- a/netlify/functions/stream.ts
+++ b/netlify/functions/stream.ts
@@ -3,16 +3,12 @@ import type { Readable } from 'node:stream';
 import { getDrive } from './_drive';
 
 /** Drive の mimeType が不正確でも拡張子から確実に audio/*
- *  に補正します（m4a=audio/mp4, mp3=audio/mpeg）。
+ *  に補正します（mp3=audio/mpeg）。
  */
 function guessAudioMime(name: string, driveMime?: string): string {
   const n = name.toLowerCase();
   if (n.endsWith('.mp3')) return 'audio/mpeg';
-  if (n.endsWith('.m4a') || n.endsWith('.aac')) return 'audio/mp4'; // AAC in MP4 想定
   if (driveMime && driveMime.startsWith('audio/')) return driveMime;
-  if ((n.endsWith('.m4a') || n.endsWith('.aac')) && driveMime === 'video/mp4') {
-    return 'audio/mp4';
-  }
   return 'audio/mpeg';
 }
 


### PR DESCRIPTION
## Summary
- drop m4a and aac handling
- search only for audio/mpeg tracks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b5b2bbe08331843e8c3c73882e2e