### PR TITLE
feat: support wav audio

### DIFF
--- a/netlify/functions/list.ts
+++ b/netlify/functions/list.ts
@@ -4,6 +4,7 @@ import { getDrive } from './_drive';
 function guessAudioMimeByName(name: string, driveMime?: string): string {
   const n = name.toLowerCase();
   if (n.endsWith('.mp3')) return 'audio/mpeg';
+  if (n.endsWith('.wav')) return 'audio/wav';
   if (driveMime && driveMime.startsWith('audio/')) return driveMime;
   return driveMime ?? 'application/octet-stream';
 }
@@ -24,7 +25,7 @@ export const handler: Handler = async () => {
     const q = [
       `'${folderId}' in parents`,
       'trashed=false',
-      "mimeType='audio/mpeg'",
+      "(mimeType='audio/mpeg' or mimeType='audio/wav' or mimeType='audio/x-wav')",
     ].join(' and ');
 
     const res = await drive.files.list({

--- a/netlify/functions/stream.ts
+++ b/netlify/functions/stream.ts
@@ -3,11 +3,12 @@ import type { Readable } from 'node:stream';
 import { getDrive } from './_drive';
 
 /** Drive の mimeType が不正確でも拡張子から確実に audio/*
- *  に補正します（mp3=audio/mpeg）。
+ *  に補正します（mp3=audio/mpeg, wav=audio/wav）。
  */
 function guessAudioMime(name: string, driveMime?: string): string {
   const n = name.toLowerCase();
   if (n.endsWith('.mp3')) return 'audio/mpeg';
+  if (n.endsWith('.wav')) return 'audio/wav';
   if (driveMime && driveMime.startsWith('audio/')) return driveMime;
   return 'audio/mpeg';
 }


### PR DESCRIPTION
## Summary
- handle WAV files alongside MP3 in streaming and listing functions
- broaden Drive query to include WAV mime types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6b7a9eb6c83318853347f7f76fc68