### PR TITLE
Remove wav support and enforce mp3 usage

### DIFF
--- a/netlify/functions/list.ts
+++ b/netlify/functions/list.ts
@@ -4,9 +4,8 @@ import { getDrive } from './_drive';
 function guessAudioMimeByName(name: string, driveMime?: string): string {
   const n = name.toLowerCase();
   if (n.endsWith('.mp3')) return 'audio/mpeg';
-  if (n.endsWith('.wav')) return 'audio/wav';
-  if (driveMime && driveMime.startsWith('audio/')) return driveMime;
-  return driveMime ?? 'application/octet-stream';
+  if (driveMime === 'audio/mpeg') return driveMime;
+  return 'audio/mpeg';
 }
 
 function errMsg(e: unknown): string {
@@ -25,7 +24,7 @@ export const handler: Handler = async () => {
     const q = [
       `'${folderId}' in parents`,
       'trashed=false',
-      "(mimeType='audio/mpeg' or mimeType='audio/wav' or mimeType='audio/x-wav')",
+      "mimeType='audio/mpeg'",
     ].join(' and ');
 
     const res = await drive.files.list({

--- a/netlify/functions/stream.ts
+++ b/netlify/functions/stream.ts
@@ -2,14 +2,13 @@ import type { Handler } from '@netlify/functions';
 import type { Readable } from 'node:stream';
 import { getDrive } from './_drive';
 
-/** Drive の mimeType が不正確でも拡張子から確実に audio/*
- *  に補正します（mp3=audio/mpeg, wav=audio/wav）。
+/** Drive の mimeType が不正確でも拡張子から確実に audio/mpeg
+ *  に補正します（mp3=audio/mpeg）。
  */
 function guessAudioMime(name: string, driveMime?: string): string {
   const n = name.toLowerCase();
   if (n.endsWith('.mp3')) return 'audio/mpeg';
-  if (n.endsWith('.wav')) return 'audio/wav';
-  if (driveMime && driveMime.startsWith('audio/')) return driveMime;
+  if (driveMime === 'audio/mpeg') return driveMime;
   return 'audio/mpeg';
 }
 


### PR DESCRIPTION
## Summary
- drop wav handling in Netlify functions
- restrict Drive query to audio/mpeg only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b9faabc88331b9df3ed238be4571