### PR TITLE
docs: add netlify dev debugging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Debugging with Netlify CLI
+
+If you need to run the development server together with Netlify Functions, start it via the Netlify CLI:
+
+```bash
+netlify dev
+```
+
+This command launches a local server with Vite and Netlify Functions for debugging.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:


### PR DESCRIPTION
## Summary
- document how to start local debugging with `netlify dev`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8085dcae88331bae9ef48c623adc2