### PR TITLE
style: center layout and teal background

### DIFF
--- a/src/components/PlayerScreen.tsx
+++ b/src/components/PlayerScreen.tsx
@@ -157,7 +157,14 @@ export default function PlayerScreen() {
   return (
     <Container
       maxWidth="sm"
-      sx={{ py: 2 }}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+        py: 2,
+      }}
       onClick={() => setUserInteracted(true)}
       onTouchStart={() => setUserInteracted(true)}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #008080;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -25,9 +25,11 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  justify-content: center;
+  align-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #008080;
 }
 
 h1 {
@@ -56,8 +58,8 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: rgba(255, 255, 255, 0.87);
+    background-color: #008080;
   }
   a:hover {
     color: #747bff;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,7 +18,10 @@ export default function LoginPage({ onLoggedIn }: { onLoggedIn: () => void }) {
   };
 
   return (
-    <Container maxWidth="xs" sx={{ py: 8 }}>
+    <Container
+      maxWidth="xs"
+      sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}
+    >
       <Card>
         <CardContent>
           {error && (


### PR DESCRIPTION
## Summary
- center login and player screens
- switch global background to teal for consistent theme

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b863f6e1d88331b59dae616dbc3173