### PR TITLE
feat: refine dark theme styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import PlayerScreen from './components/PlayerScreen';
 import LoginPage from './pages/LoginPage';
-import { CssBaseline } from '@mui/material';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
 
 export default function App() {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -10,16 +10,25 @@ export default function App() {
     setLoggedIn(localStorage.getItem('loggedIn') === '1');
   }, []);
 
+  const theme = createTheme({
+    palette: {
+      mode: 'dark',
+      background: {
+        default: '#242424',
+        paper: '#3a3a3a',
+      },
+      primary: { main: '#8fa2ff' },
+    },
+  });
+
   return (
-    <>
+    <ThemeProvider theme={theme}>
       <CssBaseline />
       {loggedIn ? (
-        <>
-          <PlayerScreen />
-        </>
+        <PlayerScreen />
       ) : (
         <LoginPage onLoggedIn={() => setLoggedIn(true)} />
       )}
-    </>
+    </ThemeProvider>
   );
 }

--- a/src/components/SortableTrackRow.tsx
+++ b/src/components/SortableTrackRow.tsx
@@ -21,7 +21,7 @@ export function SortableTrackRow({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.6 : 1,
-    background: selected ? 'rgba(25, 118, 210, 0.08)' : undefined,
+    background: selected ? 'rgba(143, 162, 255, 0.15)' : undefined,
     borderRadius: 8,
   } as const;
 

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #8fa2ff;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #b2b8ff;
 }
 
 body {
@@ -44,12 +44,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #3a3a3a;
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #8fa2ff;
 }
 button:focus,
 button:focus-visible {
@@ -62,9 +62,9 @@ button:focus-visible {
     background-color: #ffffff;
   }
   a:hover {
-    color: #747bff;
+    color: #6c79ff;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #e0e0e0;
   }
 }


### PR DESCRIPTION
## Summary
- use MUI theme with dark palette and light grey component backgrounds
- update link and button colors to complement #242424
- soften selected track highlight

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b868bf4f088331a59399be82de99cd