### PR TITLE
曲タイトルの整形処理を修正

### DIFF
--- a/netlify/functions/list.ts
+++ b/netlify/functions/list.ts
@@ -8,6 +8,15 @@ function guessAudioMimeByName(name: string, driveMime?: string): string {
   return 'audio/mpeg';
 }
 
+function formatTitle(name: string): string {
+  const underscoreIndex = name.indexOf('_');
+  if (underscoreIndex >= 0) {
+    return name.slice(0, underscoreIndex);
+  }
+  const dotIndex = name.lastIndexOf('.');
+  return dotIndex >= 0 ? name.slice(0, dotIndex) : name;
+}
+
 function errMsg(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
@@ -41,9 +50,10 @@ export const handler: Handler = async () => {
       const name = f.name ?? 'audio';
       const driveMime = f.mimeType ?? '';
       const guessed = guessAudioMimeByName(name, driveMime);
+      const title = formatTitle(name);
       return {
         id: f.id!,
-        title: name,
+        title,
         mimeType: guessed, // UI 用（<audio> canPlayType 判定に）
         driveMimeType: driveMime, // デバッグ確認用
         artwork: f.thumbnailLink ?? undefined,


### PR DESCRIPTION
## 概要
- ファイル名から曲タイトルを抽出するロジックを追加

## テスト
- `npm test` (スクリプト未定義)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86b1e1330833192db04d6bbd4f39f