### PR TITLE
feat: improve mobile playlist reordering

### DIFF
--- a/src/components/PlayerScreen.tsx
+++ b/src/components/PlayerScreen.tsx
@@ -18,7 +18,8 @@ import { PlayArrow, Pause, SkipNext, SkipPrevious } from '@mui/icons-material';
 import {
   DndContext,
   closestCenter,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
@@ -42,7 +43,10 @@ export default function PlayerScreen() {
 
   // dnd sensors
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 5 },
+    }),
     useSensor(KeyboardSensor)
   );
 

--- a/src/components/SortableTrackRow.tsx
+++ b/src/components/SortableTrackRow.tsx
@@ -31,7 +31,13 @@ export function SortableTrackRow({
         <ListItemIcon
           {...attributes}
           {...listeners}
-          sx={{ minWidth: 32, mr: 1, cursor: 'grab', color: 'text.secondary' }}
+          sx={{
+            minWidth: 40,
+            mr: 1,
+            cursor: 'grab',
+            color: 'text.secondary',
+            touchAction: 'none',
+          }}
         >
           <DragIndicator />
         </ListItemIcon>


### PR DESCRIPTION
## Summary
- use separate sensors for mouse and touch and add long-press activation
- enlarge drag handle and disable touch gestures for better mobile control

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b86f3ab4248331a89bdf128a68a537