### PR TITLE
feat: improve mobile playlist reordering

### DIFF
--- a/src/components/PlayerScreen.tsx
+++ b/src/components/PlayerScreen.tsx
@@ -18,7 +18,8 @@ import { PlayArrow, Pause, SkipNext, SkipPrevious } from '@mui/icons-material';
 import {
   DndContext,
   closestCenter,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
@@ -42,7 +43,10 @@ export default function PlayerScreen() {
 
   // dnd sensors
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 5 },
+    }),
     useSensor(KeyboardSensor)
   );
 

--- a/src/components/SortableTrackRow.tsx
+++ b/src/components/SortableTrackRow.tsx
@@ -27,11 +27,20 @@ export function SortableTrackRow({
 
   return (
     <ListItem ref={setNodeRef} style={style} disablePadding secondaryAction={null}>
-      <ListItemButton selected={selected} onClick={onClick}>
+      <ListItemButton
+        selected={selected}
+        onClick={onClick}
+        {...attributes}
+        {...listeners}
+        sx={{ touchAction: 'none', cursor: 'grab' }}
+      >
         <ListItemIcon
-          {...attributes}
-          {...listeners}
-          sx={{ minWidth: 32, mr: 1, cursor: 'grab', color: 'text.secondary' }}
+          sx={{
+            minWidth: 40,
+            mr: 1,
+            color: 'text.secondary',
+            pointerEvents: 'none',
+          }}
         >
           <DragIndicator />
         </ListItemIcon>


### PR DESCRIPTION
## Summary
- use separate sensors for mouse and touch and add long-press activation
- enlarge drag handle and disable touch gestures for better mobile control
- allow long-press drag from the entire row for easier mobile reordering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b86f3ab4248331a89bdf128a68a537