### PR TITLE
refactor player screen into modular components

### DIFF
--- a/src/components/PlayerControls.tsx
+++ b/src/components/PlayerControls.tsx
@@ -1,0 +1,164 @@
+// src/components/PlayerControls.tsx
+import {
+  Card,
+  CardContent,
+  Stack,
+  Avatar,
+  Box,
+  Typography,
+  IconButton,
+  Tooltip,
+  Slider,
+} from '@mui/material';
+import { PlayArrow, Pause, SkipNext, SkipPrevious } from '@mui/icons-material';
+import type { Track } from '../types';
+import { MutableRefObject, RefObject } from 'react';
+
+const CONTENT_MAX_W = 560;
+
+type Props = {
+  track?: Track;
+  playing: boolean;
+  canPlayThis: boolean;
+  index: number;
+  tracksLength: number;
+  current: number;
+  duration: number;
+  prev: () => void;
+  next: () => void;
+  play: () => void;
+  pause: () => void;
+  onSeek: (_: Event, v: number | number[]) => void;
+  fmt: (s: number) => string;
+  audioRef: RefObject<HTMLAudioElement>;
+  src?: string;
+  onLoaded: () => void;
+  onTime: () => void;
+  wantAutoPlayRef: MutableRefObject<boolean>;
+  interactedRef: MutableRefObject<boolean>;
+};
+
+export function PlayerControls({
+  track: t,
+  playing,
+  canPlayThis,
+  index,
+  tracksLength,
+  current,
+  duration,
+  prev,
+  next,
+  play,
+  pause,
+  onSeek,
+  fmt,
+  audioRef,
+  src,
+  onLoaded,
+  onTime,
+  wantAutoPlayRef,
+  interactedRef,
+}: Props) {
+  return (
+    <Card sx={{ mb: 2, width: '100%', maxWidth: CONTENT_MAX_W }}>
+      <CardContent>
+        {/* 上段：アートワーク＋タイトル */}
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Avatar variant="rounded" src={t?.artwork} sx={{ width: 80, height: 80 }}>
+            {t?.title?.[0]}
+          </Avatar>
+          <Box>
+            <Typography variant="h6" noWrap>
+              {t?.title ?? '—'}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {t?.artist ?? ''}
+            </Typography>
+          </Box>
+        </Stack>
+
+        {/* 中段：操作ボタンと時刻表示 */}
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }}>
+          <IconButton onClick={prev} disabled={index === 0} size="large">
+            <SkipPrevious />
+          </IconButton>
+
+          {playing ? (
+            <Tooltip title="一時停止">
+              <span>
+                <IconButton onClick={pause} disabled={!canPlayThis} size="large" color="primary">
+                  <Pause />
+                </IconButton>
+              </span>
+            </Tooltip>
+          ) : (
+            <Tooltip title="再生">
+              <span>
+                <IconButton onClick={play} disabled={!canPlayThis} size="large" color="primary">
+                  <PlayArrow />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+
+          <IconButton onClick={next} disabled={index >= tracksLength - 1} size="large">
+            <SkipNext />
+          </IconButton>
+
+          <Typography variant="body2" sx={{ ml: 1, width: 56, textAlign: 'right' }}>
+            {fmt(current)}
+          </Typography>
+          <Typography variant="body2" sx={{ width: 56, textAlign: 'left' }}>
+            {fmt(duration)}
+          </Typography>
+        </Stack>
+
+        {/* 下段：タイムライン（横幅いっぱい） */}
+        <Box sx={{ mt: 1, display: 'flex', justifyContent: 'center' }}>
+          <Slider
+            value={Math.min(current, duration)}
+            min={0}
+            max={duration || 0}
+            step={1}
+            onChange={onSeek}
+            aria-label="seek"
+            disabled={!src}
+            sx={{
+              width: '95%',
+              height: 4,
+              '& .MuiSlider-thumb': { width: 14, height: 14 },
+            }}
+          />
+        </Box>
+
+        {/* オーディオ */}
+        {src && (
+          <audio
+            ref={audioRef}
+            src={src}
+            crossOrigin="anonymous"
+            preload="metadata"
+            onLoadedMetadata={onLoaded}
+            onCanPlay={() => {
+              if (wantAutoPlayRef.current && interactedRef.current) {
+                wantAutoPlayRef.current = false;
+                void play();
+              }
+            }}
+            onTimeUpdate={onTime}
+            onEnded={next}
+            onError={(e) => {
+              const el = e.currentTarget;
+              console.error('AUDIO ERROR', el.error?.code, {
+                networkState: el.networkState,
+                readyState: el.readyState,
+                src: el.currentSrc,
+              });
+            }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/components/PlayerScreen.tsx
+++ b/src/components/PlayerScreen.tsx
@@ -1,24 +1,7 @@
 // src/components/PlayerScreen.tsx
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { Container } from '@mui/material';
 import {
-  Container,
-  Card,
-  CardContent,
-  Typography,
-  IconButton,
-  Slider,
-  List,
-  Stack,
-  Avatar,
-  Tooltip,
-  Box,
-} from '@mui/material';
-import { PlayArrow, Pause, SkipNext, SkipPrevious } from '@mui/icons-material';
-
-// dnd-kit
-import {
-  DndContext,
-  closestCenter,
   MouseSensor,
   TouchSensor,
   KeyboardSensor,
@@ -26,52 +9,12 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import type { DragEndEvent } from '@dnd-kit/core';
-import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { arrayMove } from '@dnd-kit/sortable';
 
 import type { Track } from '../types';
-import { SortableTrackRow } from './SortableTrackRow';
-
-/* -------------------- キャッシュ同期ユーティリティ -------------------- */
-
-const CACHE_NAME = 'audio-v1';
-const MANIFEST_KEY = 'audio-cache-manifest-v1'; // localStorage: { [id]: ver }
-type Manifest = Record<string, string>;
-
-function buildStreamUrl(t: Track): string {
-  const v = encodeURIComponent(t.ver ?? '');
-  return `/.netlify/functions/stream/${t.id}?v=${v}`;
-}
-
-function loadManifest(): Manifest {
-  try {
-    return JSON.parse(localStorage.getItem(MANIFEST_KEY) || '{}');
-  } catch {
-    return {};
-  }
-}
-
-function saveManifest(m: Manifest) {
-  localStorage.setItem(MANIFEST_KEY, JSON.stringify(m));
-}
-
-async function hasCached(url: string): Promise<boolean> {
-  if (!('caches' in window)) return false;
-  const cache = await caches.open(CACHE_NAME);
-  const res = await cache.match(url);
-  return !!res;
-}
-
-async function cleanupCache(validAbsUrls: string[]) {
-  if (!('caches' in window)) return;
-  const cache = await caches.open(CACHE_NAME);
-  const keys = await cache.keys();
-  const valid = new Set(validAbsUrls);
-  await Promise.all(
-    keys.map((req) => (valid.has(req.url) ? Promise.resolve() : cache.delete(req)))
-  );
-}
-
-/* -------------------------------------------------------------------- */
+import { PlayerControls } from './PlayerControls';
+import { TrackList } from './TrackList';
+import { buildStreamUrl, useAudioCache } from '../hooks/useAudioCache';
 
 export default function PlayerScreen() {
   const [tracks, setTracks] = useState<Track[]>([]);
@@ -227,93 +170,9 @@ export default function PlayerScreen() {
     });
   };
 
-  /* -------------------- 起動時の自動キャッシュ同期 -------------------- */
-
-  // 行ごとの読み込みスピナー状態
-  const [loadingById, setLoadingById] = useState<Record<string, boolean>>({});
-
-  useEffect(() => {
-    if (!tracks.length || !('caches' in window)) return;
-
-    let aborted = false;
-
-    (async () => {
-      const oldManifest = loadManifest();
-      const newManifest: Manifest = {};
-
-      // 今回の正規URL（絶対URL）一覧（掃除用）
-      const validAbsUrls: string[] = [];
-
-      // 差分収集
-      const toFetch: { id: string; url: string; reason: 'missing' | 'updated' }[] = [];
-
-      for (const t of tracks) {
-        const url = buildStreamUrl(t);
-        const absUrl = new URL(url, location.origin).href;
-        validAbsUrls.push(absUrl);
-
-        const newVer = t.ver ?? '';
-        newManifest[t.id] = newVer;
-
-        const oldVer = oldManifest[t.id];
-        if (!oldVer) {
-          // マニフェストに無い＝初回 or 新規
-          if (!(await hasCached(url))) {
-            toFetch.push({ id: t.id, url, reason: 'missing' });
-          }
-        } else if (oldVer !== newVer) {
-          toFetch.push({ id: t.id, url, reason: 'updated' });
-        }
-      }
-
-      // スピナーON
-      if (toFetch.length) {
-        setLoadingById((prev) => {
-          const next = { ...prev };
-          for (const f of toFetch) next[f.id] = true;
-          return next;
-        });
-      }
-
-      // 順次フェッチ（SW が 200 レスポンスを Cache Storage に保存）
-      const cache = await caches.open(CACHE_NAME);
-      for (const f of toFetch) {
-        if (aborted) break;
-        try {
-          await fetch(f.url, { cache: 'reload' });
-          // 旧verの掃除
-          if (f.reason === 'updated') {
-            const oldVer = oldManifest[f.id];
-            if (oldVer) {
-              const oldUrl = `/.netlify/functions/stream/${f.id}?v=${encodeURIComponent(oldVer)}`;
-              await cache.delete(new Request(oldUrl));
-            }
-          }
-        } catch (e) {
-          console.warn('prefetch failed:', f.id, e);
-        } finally {
-          setLoadingById((prev) => ({ ...prev, [f.id]: false }));
-        }
-        // 帯域にやさしく
-        await new Promise((r) => setTimeout(r, 150));
-      }
-
-      // 孤児キャッシュ掃除（別フォルダの古い曲など）
-      await cleanupCache(validAbsUrls);
-
-      // 新マニフェスト保存
-      saveManifest(newManifest);
-    })();
-
-    return () => {
-      aborted = true;
-    };
-  }, [tracks]);
-
-  /* ------------------------------------------------------------------ */
+  const loadingById = useAudioCache(tracks);
 
   const t = tracks[index];
-  const CONTENT_MAX_W = 560;
 
   return (
     <Container
@@ -328,130 +187,35 @@ export default function PlayerScreen() {
       onClick={markInteracted}
       onTouchStart={markInteracted}
     >
-      <Card sx={{ mb: 2, width: '100%', maxWidth: CONTENT_MAX_W }}>
-        <CardContent>
-          {/* 上段：アートワーク＋タイトル */}
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Avatar variant="rounded" src={t?.artwork} sx={{ width: 80, height: 80 }}>
-              {t?.title?.[0]}
-            </Avatar>
-            <Box>
-              <Typography variant="h6" noWrap>
-                {t?.title ?? '—'}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" noWrap>
-                {t?.artist ?? ''}
-              </Typography>
-            </Box>
-          </Stack>
-
-          {/* 中段：操作ボタンと時刻表示 */}
-          <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }}>
-            <IconButton onClick={prev} disabled={index === 0} size="large">
-              <SkipPrevious />
-            </IconButton>
-
-            {playing ? (
-              <Tooltip title="一時停止">
-                <span>
-                  <IconButton onClick={pause} disabled={!canPlayThis} size="large" color="primary">
-                    <Pause />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            ) : (
-              <Tooltip title="再生">
-                <span>
-                  <IconButton onClick={play} disabled={!canPlayThis} size="large" color="primary">
-                    <PlayArrow />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            )}
-
-            <IconButton onClick={next} disabled={index >= tracks.length - 1} size="large">
-              <SkipNext />
-            </IconButton>
-
-            <Typography variant="body2" sx={{ ml: 1, width: 56, textAlign: 'right' }}>
-              {fmt(current)}
-            </Typography>
-            <Typography variant="body2" sx={{ width: 56, textAlign: 'left' }}>
-              {fmt(duration)}
-            </Typography>
-          </Stack>
-
-          {/* 下段：タイムライン（横幅いっぱい） */}
-          <Box sx={{ mt: 1, display: 'flex', justifyContent: 'center' }}>
-            <Slider
-              value={Math.min(current, duration)}
-              min={0}
-              max={duration || 0}
-              step={1}
-              onChange={onSeek}
-              aria-label="seek"
-              disabled={!src}
-              sx={{
-                width: '95%',
-                height: 4,
-                '& .MuiSlider-thumb': { width: 14, height: 14 },
-              }}
-            />
-          </Box>
-
-          {/* オーディオ */}
-          {src && (
-            <audio
-              ref={audioRef}
-              src={src}
-              crossOrigin="anonymous"
-              preload="metadata"
-              onLoadedMetadata={onLoaded}
-              onCanPlay={() => {
-                if (wantAutoPlayRef.current && interactedRef.current) {
-                  wantAutoPlayRef.current = false;
-                  void play();
-                }
-              }}
-              onTimeUpdate={onTime}
-              onEnded={next}
-              onError={(e) => {
-                const el = e.currentTarget;
-                console.error('AUDIO ERROR', el.error?.code, {
-                  networkState: el.networkState,
-                  readyState: el.readyState,
-                  src: el.currentSrc,
-                });
-              }}
-            />
-          )}
-        </CardContent>
-      </Card>
-
-      {/* プレイリスト：ドラッグ&ドロップで順序変更 */}
-      <Card sx={{ width: '100%', maxWidth: CONTENT_MAX_W }}>
-        <CardContent>
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext items={tracks.map((x) => x.id)} strategy={verticalListSortingStrategy}>
-              <List>
-                {tracks.map((x, i) => (
-                  <SortableTrackRow
-                    key={x.id}
-                    track={x}
-                    selected={i === index}
-                    onClick={() => setIndex(i)}
-                    loading={!!loadingById[x.id]}
-                  />
-                ))}
-              </List>
-            </SortableContext>
-          </DndContext>
-        </CardContent>
-      </Card>
+      <PlayerControls
+        track={t}
+        playing={playing}
+        canPlayThis={canPlayThis}
+        index={index}
+        tracksLength={tracks.length}
+        current={current}
+        duration={duration}
+        prev={prev}
+        next={next}
+        play={play}
+        pause={pause}
+        onSeek={onSeek}
+        fmt={fmt}
+        audioRef={audioRef}
+        src={src}
+        onLoaded={onLoaded}
+        onTime={onTime}
+        wantAutoPlayRef={wantAutoPlayRef}
+        interactedRef={interactedRef}
+      />
+      <TrackList
+        tracks={tracks}
+        index={index}
+        setIndex={setIndex}
+        sensors={sensors}
+        handleDragEnd={handleDragEnd}
+        loadingById={loadingById}
+      />
     </Container>
   );
 }

--- a/src/components/TrackList.tsx
+++ b/src/components/TrackList.tsx
@@ -1,0 +1,49 @@
+// src/components/TrackList.tsx
+import { Card, CardContent, List } from '@mui/material';
+import { DndContext, closestCenter, type DragEndEvent, type SensorDescriptor } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import type { Track } from '../types';
+import { SortableTrackRow } from './SortableTrackRow';
+
+const CONTENT_MAX_W = 560;
+
+type Props = {
+  tracks: Track[];
+  index: number;
+  setIndex: (i: number) => void;
+  sensors: SensorDescriptor<unknown>[];
+  handleDragEnd: (e: DragEndEvent) => void;
+  loadingById: Record<string, boolean>;
+};
+
+export function TrackList({
+  tracks,
+  index,
+  setIndex,
+  sensors,
+  handleDragEnd,
+  loadingById,
+}: Props) {
+  return (
+    <Card sx={{ width: '100%', maxWidth: CONTENT_MAX_W }}>
+      <CardContent>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={tracks.map((x) => x.id)} strategy={verticalListSortingStrategy}>
+            <List>
+              {tracks.map((x, i) => (
+                <SortableTrackRow
+                  key={x.id}
+                  track={x}
+                  selected={i === index}
+                  onClick={() => setIndex(i)}
+                  loading={!!loadingById[x.id]}
+                />
+              ))}
+            </List>
+          </SortableContext>
+        </DndContext>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/hooks/useAudioCache.ts
+++ b/src/hooks/useAudioCache.ts
@@ -1,0 +1,126 @@
+// src/hooks/useAudioCache.ts
+import { useEffect, useState } from 'react';
+import type { Track } from '../types';
+
+const CACHE_NAME = 'audio-v1';
+const MANIFEST_KEY = 'audio-cache-manifest-v1';
+type Manifest = Record<string, string>;
+
+export function buildStreamUrl(t: Track): string {
+  const v = encodeURIComponent(t.ver ?? '');
+  return `/.netlify/functions/stream/${t.id}?v=${v}`;
+}
+
+function loadManifest(): Manifest {
+  try {
+    return JSON.parse(localStorage.getItem(MANIFEST_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function saveManifest(m: Manifest) {
+  localStorage.setItem(MANIFEST_KEY, JSON.stringify(m));
+}
+
+async function hasCached(url: string): Promise<boolean> {
+  if (!('caches' in window)) return false;
+  const cache = await caches.open(CACHE_NAME);
+  const res = await cache.match(url);
+  return !!res;
+}
+
+async function cleanupCache(validAbsUrls: string[]) {
+  if (!('caches' in window)) return;
+  const cache = await caches.open(CACHE_NAME);
+  const keys = await cache.keys();
+  const valid = new Set(validAbsUrls);
+  await Promise.all(
+    keys.map((req) => (valid.has(req.url) ? Promise.resolve() : cache.delete(req)))
+  );
+}
+
+export function useAudioCache(tracks: Track[]) {
+  const [loadingById, setLoadingById] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (!tracks.length || !('caches' in window)) return;
+
+    let aborted = false;
+
+    (async () => {
+      const oldManifest = loadManifest();
+      const newManifest: Manifest = {};
+
+      // 今回の正規URL（絶対URL）一覧（掃除用）
+      const validAbsUrls: string[] = [];
+
+      // 差分収集
+      const toFetch: { id: string; url: string; reason: 'missing' | 'updated' }[] = [];
+
+      for (const t of tracks) {
+        const url = buildStreamUrl(t);
+        const absUrl = new URL(url, location.origin).href;
+        validAbsUrls.push(absUrl);
+
+        const newVer = t.ver ?? '';
+        newManifest[t.id] = newVer;
+
+        const oldVer = oldManifest[t.id];
+        if (!oldVer) {
+          // マニフェストに無い＝初回 or 新規
+          if (!(await hasCached(url))) {
+            toFetch.push({ id: t.id, url, reason: 'missing' });
+          }
+        } else if (oldVer !== newVer) {
+          toFetch.push({ id: t.id, url, reason: 'updated' });
+        }
+      }
+
+      // スピナーON
+      if (toFetch.length) {
+        setLoadingById((prev) => {
+          const next = { ...prev };
+          for (const f of toFetch) next[f.id] = true;
+          return next;
+        });
+      }
+
+      // 順次フェッチ（SW が 200 レスポンスを Cache Storage に保存）
+      const cache = await caches.open(CACHE_NAME);
+      for (const f of toFetch) {
+        if (aborted) break;
+        try {
+          await fetch(f.url, { cache: 'reload' });
+          // 旧verの掃除
+          if (f.reason === 'updated') {
+            const oldVer = oldManifest[f.id];
+            if (oldVer) {
+              const oldUrl = `/.netlify/functions/stream/${f.id}?v=${encodeURIComponent(oldVer)}`;
+              await cache.delete(new Request(oldUrl));
+            }
+          }
+        } catch (e) {
+          console.warn('prefetch failed:', f.id, e);
+        } finally {
+          setLoadingById((prev) => ({ ...prev, [f.id]: false }));
+        }
+        // 帯域にやさしく
+        await new Promise((r) => setTimeout(r, 150));
+      }
+
+      // 孤児キャッシュ掃除（別フォルダの古い曲など）
+      await cleanupCache(validAbsUrls);
+
+      // 新マニフェスト保存
+      saveManifest(newManifest);
+    })();
+
+    return () => {
+      aborted = true;
+    };
+  }, [tracks]);
+
+  return loadingById;
+}
+


### PR DESCRIPTION
## Summary
- split long PlayerScreen into smaller PlayerControls and TrackList components
- extract audio cache logic into reusable hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b94abda0a4833186f2fc690ca94d5c