### PR TITLE
refactor: split PlayerScreen into smaller components

### DIFF
--- a/src/components/PlayerControls.tsx
+++ b/src/components/PlayerControls.tsx
@@ -1,0 +1,155 @@
+// src/components/PlayerControls.tsx
+import { Card, CardContent, Stack, Avatar, Box, Typography, IconButton, Tooltip, Slider } from '@mui/material';
+import { PlayArrow, Pause, SkipNext, SkipPrevious } from '@mui/icons-material';
+import type { Track } from '../types';
+import type { MutableRefObject, RefObject } from 'react';
+
+type Props = {
+  track?: Track;
+  index: number;
+  tracksLength: number;
+  playing: boolean;
+  duration: number;
+  current: number;
+  canPlayThis: boolean;
+  src?: string;
+  prev: () => void;
+  next: () => void;
+  play: () => Promise<void> | void;
+  pause: () => void;
+  onSeek: (_: Event, v: number | number[]) => void;
+  onLoaded: () => void;
+  onTime: () => void;
+  audioRef: RefObject<HTMLAudioElement | null>;
+  wantAutoPlayRef: MutableRefObject<boolean>;
+  interactedRef: MutableRefObject<boolean>;
+  fmt: (s: number) => string;
+  maxWidth: number;
+};
+
+export function PlayerControls({
+  track: t,
+  index,
+  tracksLength,
+  playing,
+  duration,
+  current,
+  canPlayThis,
+  src,
+  prev,
+  next,
+  play,
+  pause,
+  onSeek,
+  onLoaded,
+  onTime,
+  audioRef,
+  wantAutoPlayRef,
+  interactedRef,
+  fmt,
+  maxWidth,
+}: Props) {
+  return (
+    <Card sx={{ mb: 2, width: '100%', maxWidth }}>
+      <CardContent>
+        {/* 上段：アートワーク＋タイトル */}
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Avatar variant="rounded" src={t?.artwork} sx={{ width: 80, height: 80 }}>
+            {t?.title?.[0]}
+          </Avatar>
+          <Box>
+            <Typography variant="h6" noWrap>
+              {t?.title ?? '—'}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {t?.artist ?? ''}
+            </Typography>
+          </Box>
+        </Stack>
+
+        {/* 中段：操作ボタンと時刻表示 */}
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }}>
+          <IconButton onClick={prev} disabled={index === 0} size="large">
+            <SkipPrevious />
+          </IconButton>
+
+          {playing ? (
+            <Tooltip title="一時停止">
+              <span>
+                <IconButton onClick={pause} disabled={!canPlayThis} size="large" color="primary">
+                  <Pause />
+                </IconButton>
+              </span>
+            </Tooltip>
+          ) : (
+            <Tooltip title="再生">
+              <span>
+                <IconButton onClick={play} disabled={!canPlayThis} size="large" color="primary">
+                  <PlayArrow />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+
+          <IconButton onClick={next} disabled={index >= tracksLength - 1} size="large">
+            <SkipNext />
+          </IconButton>
+
+          <Typography variant="body2" sx={{ ml: 1, width: 56, textAlign: 'right' }}>
+            {fmt(current)}
+          </Typography>
+          <Typography variant="body2" sx={{ width: 56, textAlign: 'left' }}>
+            {fmt(duration)}
+          </Typography>
+        </Stack>
+
+        {/* 下段：タイムライン（横幅いっぱい） */}
+        <Box sx={{ mt: 1, display: 'flex', justifyContent: 'center' }}>
+          <Slider
+            value={Math.min(current, duration)}
+            min={0}
+            max={duration || 0}
+            step={1}
+            onChange={onSeek}
+            aria-label="seek"
+            disabled={!src}
+            sx={{
+              width: '95%',
+              height: 4,
+              '& .MuiSlider-thumb': { width: 14, height: 14 },
+            }}
+          />
+        </Box>
+
+        {/* オーディオ */}
+        {src && (
+          <audio
+            ref={audioRef}
+            src={src}
+            crossOrigin="anonymous"
+            preload="metadata"
+            onLoadedMetadata={onLoaded}
+            onCanPlay={() => {
+              if (wantAutoPlayRef.current && interactedRef.current) {
+                wantAutoPlayRef.current = false;
+                void play();
+              }
+            }}
+            onTimeUpdate={onTime}
+            onEnded={next}
+            onError={(e) => {
+              const el = e.currentTarget;
+              console.error('AUDIO ERROR', el.error?.code, {
+                networkState: el.networkState,
+                readyState: el.readyState,
+                src: el.currentSrc,
+              });
+            }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default PlayerControls;

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,0 +1,56 @@
+// src/components/Playlist.tsx
+import { Card, CardContent, List } from '@mui/material';
+import {
+  DndContext,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { SortableTrackRow } from './SortableTrackRow';
+import type { Track } from '../types';
+
+type Props = {
+  tracks: Track[];
+  index: number;
+  setIndex: (i: number) => void;
+  handleDragEnd: (e: DragEndEvent) => void;
+  loadingById: Record<string, boolean>;
+  maxWidth: number;
+};
+
+export function Playlist({ tracks, index, setIndex, handleDragEnd, loadingById, maxWidth }: Props) {
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+    useSensor(KeyboardSensor)
+  );
+
+  return (
+    <Card sx={{ width: '100%', maxWidth }}>
+      <CardContent>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={tracks.map((x) => x.id)} strategy={verticalListSortingStrategy}>
+            <List>
+              {tracks.map((x, i) => (
+                <SortableTrackRow
+                  key={x.id}
+                  track={x}
+                  selected={i === index}
+                  onClick={() => setIndex(i)}
+                  loading={!!loadingById[x.id]}
+                />
+              ))}
+            </List>
+          </SortableContext>
+        </DndContext>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Playlist;


### PR DESCRIPTION
## Summary
- extract PlayerControls component for playback UI
- extract Playlist component for sortable track list
- integrate new components into PlayerScreen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b94abda0a4833186f2fc690ca94d5c