### PR TITLE
プレイリストに「ゆもしんが考えた曲順」ボタンを追加

### DIFF
--- a/src/components/PlayerScreen.tsx
+++ b/src/components/PlayerScreen.tsx
@@ -10,6 +10,17 @@ import { useCacheSync } from '../hooks/useCacheSync';
 import { PlayerControls } from './PlayerControls';
 import { Playlist } from './Playlist';
 
+const YUMOSHIN_TITLES = [
+  'ghost mi#',
+  'noah',
+  'ほしを継ぐもの',
+  'flowers3',
+  'milkomeda',
+  'for Lib Isl',
+  '螺旋とは',
+  'Impulse',
+];
+
 export default function PlayerScreen() {
   const [tracks, setTracks] = useState<Track[]>([]);
   const [index, setIndex] = useState(0);
@@ -172,6 +183,25 @@ export default function PlayerScreen() {
     });
   };
 
+  const handleYumoshinOrder = useCallback(() => {
+    setTracks((prev) => {
+      const order = new Map(YUMOSHIN_TITLES.map((t, i) => [t, i]));
+      const sorted = [...prev].sort((a, b) => {
+        const ai = order.get(a.title);
+        const bi = order.get(b.title);
+        if (ai === undefined && bi === undefined) return 0;
+        if (ai === undefined) return 1;
+        if (bi === undefined) return -1;
+        return ai - bi;
+      });
+      const currentId = prev[index]?.id;
+      const newIdx = sorted.findIndex((t) => t.id === currentId);
+      setIndex(newIdx >= 0 ? newIdx : 0);
+      localStorage.setItem('trackOrder', JSON.stringify(sorted.map((t) => t.id)));
+      return sorted;
+    });
+  }, [index]);
+
   /* -------------------- 起動時の自動キャッシュ同期 -------------------- */
   const { loadingById } = useCacheSync(tracks);
   /* ------------------------------------------------------------------ */
@@ -223,6 +253,7 @@ export default function PlayerScreen() {
         handleDragEnd={handleDragEnd}
         loadingById={loadingById}
         maxWidth={CONTENT_MAX_W}
+        onYumoshinOrder={handleYumoshinOrder}
       />
     </Container>
   );

--- a/src/components/Playlist.tsx
+++ b/src/components/Playlist.tsx
@@ -1,5 +1,5 @@
 // src/components/Playlist.tsx
-import { Card, CardContent, List } from '@mui/material';
+import { Card, CardContent, List, Button } from '@mui/material';
 import {
   DndContext,
   closestCenter,
@@ -21,9 +21,10 @@ type Props = {
   handleDragEnd: (e: DragEndEvent) => void;
   loadingById: Record<string, boolean>;
   maxWidth: number;
+  onYumoshinOrder: () => void;
 };
 
-export function Playlist({ tracks, index, setIndex, handleDragEnd, loadingById, maxWidth }: Props) {
+export function Playlist({ tracks, index, setIndex, handleDragEnd, loadingById, maxWidth, onYumoshinOrder }: Props) {
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 6 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
@@ -32,7 +33,22 @@ export function Playlist({ tracks, index, setIndex, handleDragEnd, loadingById, 
 
   return (
     <Card sx={{ width: '100%', maxWidth }}>
-      <CardContent>
+      <CardContent sx={{ position: 'relative' }}>
+        <Button
+          onClick={onYumoshinOrder}
+          size="small"
+          variant="outlined"
+          sx={{
+            position: 'absolute',
+            top: 4,
+            right: 4,
+            fontSize: '0.6rem',
+            minWidth: 0,
+            p: '2px 4px',
+          }}
+        >
+          ゆもしんが考えた曲順
+        </Button>
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={tracks.map((x) => x.id)} strategy={verticalListSortingStrategy}>
             <List>


### PR DESCRIPTION
## Summary
- プレイリスト右上に「ゆもしんが考えた曲順」ボタンを追加
- クリックで指定の曲順に並び替え、localStorageへ保存

## Testing
- `npm test`（スクリプトなし）
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba89c9870083318e0427fbf3875126